### PR TITLE
build(deps): fix dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
-    time: "15:00"
+      time: "15:00"
     assignees:
       - 'QingqiShi'
     open-pull-requests-limit: 10
@@ -14,7 +14,7 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
-    time: "15:00"
+      time: "15:00"
     assignees:
       - 'QingqiShi'
     open-pull-requests-limit: 10


### PR DESCRIPTION
`time` property need to be within the `schedule` property