### PR TITLE
build(deps): fix dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
-      time: "15:00"
+      time: '15:00'
     assignees:
       - 'QingqiShi'
     open-pull-requests-limit: 10
@@ -14,8 +14,7 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
-      time: "15:00"
+      time: '15:00'
     assignees:
       - 'QingqiShi'
     open-pull-requests-limit: 10
-    versioning-strategy: increase


### PR DESCRIPTION
`github-action` doesn't support `version-strategy`